### PR TITLE
made export screen stay always on

### DIFF
--- a/app/src/main/java/app/wristkey/ExportActivity.kt
+++ b/app/src/main/java/app/wristkey/ExportActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.util.Log
 import android.view.HapticFeedbackConstants
 import android.view.View
+import android.view.WindowManager
 import android.widget.TextView
 import android.widget.Toast
 import androidx.annotation.RequiresApi
@@ -37,6 +38,7 @@ class ExportActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_export)
+        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
 
         utilities = Utilities (applicationContext)
         mfaCodesTimer = Timer()


### PR DESCRIPTION
### What's new
- Added file picker option for devices that support it
- New monochrome colors to be more platform agnostic
- Fixed import bugs.
- Made export screen stay always on

### Bug fixes
- Fixed a bug with `decodeOtpAuthUrl()` where the period parameter could get extracted incorrectly
