### PR TITLE
[FEAT]: allows rotating input for wear os devices that have a rotate crown

### DIFF
--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -12,7 +12,12 @@
 
     <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        android:scrollbars="vertical"
+        android:fadeScrollbars="false">
+        <requestFocus/>
 
         <LinearLayout
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/activity_add.xml
+++ b/app/src/main/res/layout/activity_add.xml
@@ -13,7 +13,12 @@
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:fillViewport="true">
+        android:fillViewport="true"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        android:scrollbars="vertical"
+        android:fadeScrollbars="false">
+        <requestFocus/>
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_aegis_jsonimport.xml
+++ b/app/src/main/res/layout/activity_aegis_jsonimport.xml
@@ -12,7 +12,12 @@
 
 <ScrollView
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:focusable="true"
+    android:focusableInTouchMode="true"
+    android:scrollbars="vertical"
+    android:fadeScrollbars="false">
+    <requestFocus/>
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_andotp_jsonimport.xml
+++ b/app/src/main/res/layout/activity_andotp_jsonimport.xml
@@ -12,7 +12,12 @@
 
     <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        android:scrollbars="vertical"
+        android:fadeScrollbars="false">
+        <requestFocus/>
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_authenticator_qrimport.xml
+++ b/app/src/main/res/layout/activity_authenticator_qrimport.xml
@@ -12,7 +12,12 @@
 
     <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        android:scrollbars="vertical"
+        android:fadeScrollbars="false">
+        <requestFocus/>
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_bitwarden_jsonimport.xml
+++ b/app/src/main/res/layout/activity_bitwarden_jsonimport.xml
@@ -12,7 +12,12 @@
 
     <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        android:scrollbars="vertical"
+        android:fadeScrollbars="false">
+        <requestFocus/>
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_delete.xml
+++ b/app/src/main/res/layout/activity_delete.xml
@@ -12,7 +12,12 @@
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:fillViewport="true">
+        android:fillViewport="true"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        android:scrollbars="vertical"
+        android:fadeScrollbars="false">
+        <requestFocus/>
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_export.xml
+++ b/app/src/main/res/layout/activity_export.xml
@@ -14,7 +14,12 @@
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:fillViewport="true">
+        android:fillViewport="true"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        android:scrollbars="vertical"
+        android:fadeScrollbars="false">
+        <requestFocus/>
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -16,8 +16,12 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="@+id/RoundTimeLeft"
         app:layout_constraintStart_toStartOf="parent"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        android:scrollbars="vertical"
+        android:fadeScrollbars="false"
         app:layout_constraintTop_toTopOf="parent">
-
+        <requestFocus/>
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_manual_entry.xml
+++ b/app/src/main/res/layout/activity_manual_entry.xml
@@ -14,7 +14,12 @@
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:fillViewport="true">
+        android:fillViewport="true"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        android:scrollbars="vertical"
+        android:fadeScrollbars="false">
+        <requestFocus/>
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_otpauth_import.xml
+++ b/app/src/main/res/layout/activity_otpauth_import.xml
@@ -12,7 +12,12 @@
 
     <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        android:scrollbars="vertical"
+        android:fadeScrollbars="false">
+        <requestFocus/>
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_qrcode.xml
+++ b/app/src/main/res/layout/activity_qrcode.xml
@@ -12,7 +12,12 @@
 
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        android:scrollbars="vertical"
+        android:fadeScrollbars="false">
+        <requestFocus/>
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -14,7 +14,12 @@
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        android:scrollbars="vertical"
+        android:fadeScrollbars="false"
         android:fillViewport="true">
+        <requestFocus />
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_wristkey_import.xml
+++ b/app/src/main/res/layout/activity_wristkey_import.xml
@@ -12,7 +12,12 @@
 
     <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        android:scrollbars="vertical"
+        android:fadeScrollbars="false">
+        <requestFocus/>
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/import_loading_screen.xml
+++ b/app/src/main/res/layout/import_loading_screen.xml
@@ -11,7 +11,12 @@
 
     <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        android:scrollbars="vertical"
+        android:fadeScrollbars="false">
+        <requestFocus/>
 
         <LinearLayout
             android:layout_width="match_parent"


### PR DESCRIPTION
This is a simple Pull request which allows rotating input for wear os devices that have a rotate crown
just make a small change of layout and it worked. Tested by using android studio's wear os 3 device and by pixel 4 (VM too) and it works fine without crashing

Let me know if there is any problem with this code. Thank you!